### PR TITLE
Fix 'log format ignored' messages during startup of HAproxy

### DIFF
--- a/proxy/src/proxy_config.cfg
+++ b/proxy/src/proxy_config.cfg
@@ -41,8 +41,8 @@ defaults
   timeout connect 5s
   timeout client 200s
   timeout server 200s
-  log global
-  option tcplog
+  # log global
+  # option tcplog
   default-server inter 10s fastinter 1s downinter 3s error-limit 50
 
 listen stats


### PR DESCRIPTION
This is caused due to the absence of a global logging configuration. While in the defautls section, this global config is referred to.

As the logging endpoint was commented out in the global section, there is no need to have any other logging configuration around.