### PR TITLE
Added explicit file ending to sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Explicitly declare sh files to always be normalized and have LF file endings
+*.sh text eol=lf

--- a/proxy/src/generate-certs.sh
+++ b/proxy/src/generate-certs.sh
@@ -93,3 +93,4 @@ cat ${SSL_KEY} > proxy.whatsapp.net.pem
 cat ${SSL_CERT} >> proxy.whatsapp.net.pem
 
 echo "Certificate generation completed."
+

--- a/proxy/src/healthcheck.sh
+++ b/proxy/src/healthcheck.sh
@@ -24,3 +24,4 @@ then
 fi
 
 exit 0;
+

--- a/proxy/src/set_public_ip_and_start.sh
+++ b/proxy/src/set_public_ip_and_start.sh
@@ -52,3 +52,4 @@ popd
 
 # Start HAProxy
 haproxy -f "$CONFIG_FILE"
+


### PR DESCRIPTION
This is with reference to https://github.com/WhatsApp/proxy/issues/64

When repo is clone, sometimes the line ending cause problems during docker build, so I have added gitattributes to define line ending on the sh files explicitly.

Also, I have just added a new line at the end of the .sh file and normalized them.