### PR TITLE
Create bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug Report
+about: Report a bug for the proxy
+---
+**Before reporting a bug, please see our FAQ in [FAQ.md](https://github.com/whatsapp/proxy/blob/main/FAQ.md)!**
+
+#### Description
+<!-- Describe the bug here, be as specific as possible. -->
+
+#### Failed Step
+
+<!-- 
+There are several steps to successfully build and run a proxy. Each step
+in the README describes how one can check whether the step has succeeded.
+Include the name of the step that failed here from the list:
+
+Setup
+1. Clone the repository to your local machine
+2. Install Docker for your system
+2. (Optional) Install Docker compose
+3. Build the proxy host container
+
+Running the proxy
+1. Manually execute the container
+2. Check your connection
+-->
+
+#### More Details
+<!-- Add which commands you run in the failed step, what the outputs were. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ about: Report a bug for the proxy
 <!-- 
 There are several steps to successfully build and run a proxy. Each step
 in the README describes how one can check whether the step has succeeded.
-Include the name of the step that failed here from the list:
+Include the name of the step that **failed** from the list:
 
 Setup
 1. Clone the repository to your local machine
@@ -27,3 +27,6 @@ Running the proxy
 
 #### More Details
 <!-- Add which commands you run in the failed step, what the outputs were. -->
+
+<!-- Add the platform information you are on (operating system, Docker version etc.)
+(never share private information!) -->


### PR DESCRIPTION
Adding a template to standardize bug reports. README already contains how to confirm each step succeeded. This report focuses on the failed step and tries to gather as much information as possible.

Open to edits, feel free to update if there is other information needed to address bugs.