### PR TITLE
Adding automatic docker publishes on pushes to main

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,52 @@
+name: Docker Image CI
+
+# Run on every push to main + weekly, Sunday @ midnight
+# to keep the image fresh
+on:
+  push:
+    branches: [ "main" ]
+  schedule:
+    - cron: "0 0 * * 0"
+  # On pull-requests only a build is run, not a push to Docker Hub
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Docker metadata
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: facebook/whatsapp_proxy
+        tags: |
+          type=raw,value={{date 'YYYYMMDD'}}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      
+    - name: Login to dockerhub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+    - name: Build and push
+      uses: docker/build-push-action@v3
+      with:
+        context: ./proxy
+        platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: |
+          ${{ steps.meta.outputs.tags }}
+          facebook/whatsapp_proxy:latest
+      


### PR DESCRIPTION
This was tested by using this PR, but I can confirm docker login is successful and it does NOT publish on PRs but should run weekly to re-publish an updated version (keeping HAProxy in-sync) additionally it'll republish on every merge to `main`.