### PR TITLE
docs: fix repetion in the comments

### DIFF
--- a/proxy/src/set_public_ip_and_start.sh
+++ b/proxy/src/set_public_ip_and_start.sh
@@ -6,7 +6,7 @@
 
 ## About:
 # This script replaces instances of #PUBLIC_IP in the HaProxy configuration files
-# with the the real public ip. There's an order of priority here which is
+# with the real public ip. There's an order of priority here which is
 # 1. Environment variable
 # 2. AWS EC2 Metadata endpoint
 # 3. Third-party sources


### PR DESCRIPTION
This simple PR removes a redundant 'the' in the comments