### PR TITLE
Use Traefik instead of HAProxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ docker ps
 
 *\*Make sure to update the path to your specific `docker-compose.yml` file in the service definition `docker_boot.service`*
 
+## Alternative Traefik proxy
+
+For a simpler and more versatile configuration using traefik, see [traefik/README.md](traefik/README.md)
+
 ## Kubernetes deployment
 
 If you would like to configure your proxy using Kubernetes, or run the Docker runtime through Kubernetes, please see our [Helm chart README](./charts/README.md)

--- a/traefik/README.md
+++ b/traefik/README.md
@@ -1,0 +1,93 @@
+# WhatsApp Chat Proxy (traefik version)
+
+[<img alt="github" src="https://img.shields.io/badge/github-WhatsApp/proxy-8da0cb?style=for-the-badge&labelColor=555555&logo=github" height="20">](https://github.com/WhatsApp/proxy)
+[![CI](https://github.com/WhatsApp/proxy/actions/workflows/ci.yml/badge.svg)](https://github.com/WhatsApp/proxy/actions/workflows/ci.yml)
+
+If you are unable to connect directly to WhatsApp, a proxy can be used as a gateway between you and our servers. To help yourself or others re-establish connection to WhatsApp, you can set up a proxy server.
+
+If you already have a proxy to use, you can connect it to WhatsApp by following the steps in this [article](https://faq.whatsapp.com/520504143274092).
+
+## Frequently asked questions
+
+**PLEASE READ THIS BEFORE OPENING AN ISSUE** We have an FAQ, which you can find here: [FAQ.md](https://github.com/whatsapp/proxy/blob/main/FAQ.md)
+
+## What you'll need
+
+1. [Docker](https://docs.docker.com/engine/install/) (enable Docker on startup if your host system allows)
+2. [Docker compose](https://docs.docker.com/compose/)
+
+## Setting up your proxy
+
+### 1. Clone the repository to your local machine
+
+```bash
+git clone https://github.com/WhatsApp/proxy.git
+```
+
+You should see a folder called `proxy` created in the current directory.
+
+
+### 2. [Install Docker](https://docs.docker.com/get-docker/) for your system
+
+To confirm Docker is successfully installed:
+
+```bash
+docker --version
+```
+
+should display a line similar to `Docker version 20.10.21, build baeda1f`.
+
+### 2. Install Docker compose
+
+For Linux users, if your [version of Docker](https://docs.docker.com/desktop/install/linux-install/) doesn't come pre-installed with Docker compose, you can install Docker compose separately. The following command is for Debian and Ubuntu. Please refer to the [Docker documentation](https://docs.docker.com/compose/install/) for other installation options.
+
+```bash
+sudo apt-get update
+sudo apt-get install docker-compose-plugin
+```
+
+## Running the proxy
+
+### Check the configurations
+
+The default configuration will be using traefik proxy with self-signed TLS certificates and [traefik.me](https://traefik.me/) as wildcard dns provider. This setup should work in most cases. However, if you are a power user or have specific preferences, for example:
+
+- Use your own domain instead of default wildcard DNS
+- Bring your own certificate files
+- Use Let's Encrypt or other ACME providers
+- Use alternative wildcard DNS providers
+- Uirectly use IP addresses for connection (strongly **NOT** recommanded)
+
+You can check the comments in configuration files and [Traefik Documentation](https://doc.traefik.io/traefik/) for more information.
+
+### Set up Traefik proxy service
+
+```
+cd proxy/traefik
+docker compose up -d && docker compose logs -f
+```
+
+If Traefik service is started successfully, it should display a line like `Configuration loaded from file: /etc/traefik/traefik.toml`
+
+The service is automatically started on host boot, no more configuration is needed. If you want to stop and remove the service, run `docker compose down` inside the directory with *compose.yml* file.
+
+The Traefik service does not exclusively occupy 80/443 and other ports on its own. It functions as a versatile reverse proxy with a wide range of features, similar to HAProxy and Nginx. For more advanced usage and how to Traefik as reverse proxy for other web services, please refer to [Traefik documentation](https://doc.traefik.io/traefik/).
+
+## Configure your WhatsApp client
+
+Assuming your proxy server is running on IP 192.168.1.1, then set your WhatsApp *Proxy host* to the following domain name.
+
+```
+whatsapp-192.168.1.1.traefik.me
+```
+
+Optionally, you can set the port numbers if default ports are blocked or you're under other network restrictions.
+
+- Chat port
+  - 443 (select "Use TLS"), default value.
+  - 5222 (select "Use TLS")
+  - 80
+- Media port
+  - 587, default value.
+  - 7777
+

--- a/traefik/compose.yml
+++ b/traefik/compose.yml
@@ -1,0 +1,37 @@
+services:
+  traefik:
+    image: traefik:v2.10.5
+    container_name: reverse_proxy
+    restart: "always"
+    environment:
+      # - TRAEFIK_LOG_LEVEL=WARNING
+      - LEGO_CA_SYSTEM_CERT_POOL=true
+      # - LEGO_CA_CERTIFICATES=/path/to/custom/ca.crt
+
+      ## use dns challenge if you want wildcard certificates from LetsEncrypt
+      # - ACME_DNS_API_BASE=https://auth.acme-dns.io
+      # - ACME_DNS_STORAGE_PATH=/ssl/lego.acme-dns.json
+    ports:
+      # whatsapp_chat_tcp_stdport
+      - "80:80"
+      # whatsapp_chat_tls_stdport
+      - "443:443"
+      # whatsapp_chat_tls
+      - "5222:5222"
+      # whatsapp_media_stdport
+      - "587:587"
+      # whatsapp_media
+      - "7777:7777"
+    volumes:
+      # Here is the mount of the traefik config
+      - {type: bind, source: "./config", target: "/etc/traefik"}
+
+networks:
+  # gateway: {external: true, name: gateway}
+  gateway:
+    name: gateway
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.12.0.0/16
+

--- a/traefik/config/dynamic/whatsapp_proxy.toml
+++ b/traefik/config/dynamic/whatsapp_proxy.toml
@@ -36,7 +36,7 @@ service = "whatsapp-chat"
 
 [tcp.routers.whatsapp-media]
 entrypoints = ["whatsapp_media", "whatsapp_media_stdport"]
-rule = "HostSNIRegexp(`media-[a-z1-9-]+.cdn.whatsapp.net`, `whatsapp-{ip:.*}.traefik.me`)"  # `whatsapp.net`, `mmg.whatsapp.net`,
+rule = "HostSNIRegexp(`media-[a-z1-9-]+.cdn.whatsapp.net`, `whatsapp-{ip:.*}.traefik.me`) || HostSNI(`mmg.whatsapp.net`)"  # `whatsapp.net`
 service = "whatsapp-media"
 [tcp.routers.whatsapp-media.tls]
 passthrough = true

--- a/traefik/config/dynamic/whatsapp_proxy.toml
+++ b/traefik/config/dynamic/whatsapp_proxy.toml
@@ -1,0 +1,47 @@
+## TLS termination for chat traffic, use letsencrypt or self signed certificate
+[tcp.routers.whatsapp-chat-tls]
+entrypoints = ["whatsapp_chat_tls", "whatsapp_chat_tls_stdport"]
+rule = "HostSNIRegexp(`whatsapp-{ip:.*}.traefik.me`)"
+service = "whatsapp-chat"
+
+[tcp.routers.whatsapp-chat-tls.tls]
+## Option 1 (default): use self-signed certificate
+
+## Option 2: uncomment this line to use LetsEncrypt
+# certResolver = "leprod"
+
+## Option 3: import certificate from file, mounted from ./config/ssl directory
+# [tls.stores]
+#   [tls.stores.default]
+
+# [[tls.certificates]]
+#   certFile = "/etc/traefik/ssl/your_domain.pem"
+#   keyFile = "/etc/traefik/ssl/your_domain.key"
+
+
+[tcp.routers.whatsapp-chat-tcp]
+# this router will occupy the entire 80 port!
+# if you have other plans for 80 port, you can comment it out safely,
+# chat service is served by 443 port, and 80 port is only used as a fallback.
+entrypoints = ["whatsapp_chat_tcp_stdport"]
+rule = "ClientIP(`0.0.0.0/0`)"
+service = "whatsapp-chat"
+
+[tcp.services.whatsapp-chat.loadBalancer]
+[[tcp.services.whatsapp-chat.loadBalancer.servers]]
+  ## port 5222 and 80 can be used interchangeably, 80 port is chosen in case of restrictive networks.
+  address = "g.whatsapp.net:80"
+  # address = "g.whatsapp.net:5222"
+  # address = "port-forwarder:5222"
+
+[tcp.routers.whatsapp-media]
+entrypoints = ["whatsapp_media", "whatsapp_media_stdport"]
+rule = "HostSNIRegexp(`media-[a-z1-9-]+.cdn.whatsapp.net`, `whatsapp-{ip:.*}.traefik.me`)"  # `whatsapp.net`, `mmg.whatsapp.net`,
+service = "whatsapp-media"
+[tcp.routers.whatsapp-media.tls]
+passthrough = true
+
+[tcp.services.whatsapp-media.loadBalancer]
+[[tcp.services.whatsapp-media.loadBalancer.servers]]
+  address = "whatsapp.net:443"
+  # address = "port-forwarder:5443"

--- a/traefik/config/traefik.toml
+++ b/traefik/config/traefik.toml
@@ -1,0 +1,44 @@
+[entryPoints]
+  [entryPoints.whatsapp_chat_tcp_stdport]
+    address = ":80"
+  [entryPoints.whatsapp_chat_tls_stdport]
+    address = ":443"
+  [entryPoints.whatsapp_chat_tls]
+    address = ":5222"
+  [entryPoints.whatsapp_media_stdport]
+    address = ":587"
+  [entryPoints.whatsapp_media]
+    address = ":7777"
+
+## uncomment these lines to enable LetsEncrypt
+
+# [certificatesResolvers.leprod.acme]
+#   email = "acme@example.com"
+#   storage = "/etc/traefik/ssl/leprod.json"
+
+#   ## use tls challenge for most cases
+#   [certificatesResolvers.leprod.acme.tlsChallenge]
+
+#   ## use dns challenge if you want wildcard certificates from LetsEncrypt
+#   # [certificatesResolvers.leprod.acme.dnsChallenge]
+#   #   provider = "acme-dns"
+#   #   # delayBeforeCheck = 0
+
+
+
+[providers.file]
+  directory = "/etc/traefik/dynamic/"
+
+[serversTransport]
+  rootCAs = ["/etc/ssl/cert.pem"]  # "/path/to/custom/ca.crt",
+
+[api]
+
+[log]
+  level = "WARNING"
+  # level = "DEBUG"
+
+[accessLog]
+
+# [experimental.localPlugins.fail2ban]
+#   moduleName = "github.com/tomMoulard/fail2ban"


### PR DESCRIPTION
This PR adds a full configuration to setup a WhatsApp proxy with [Traefik](https://doc.traefik.io/traefik/), expose similar ports to existing haproxy configuration, but with a much simpler setup process and more versatile configurations.

The main advantages over HAProxy include:

1. No more building process. only a compose file and [traefik image from docker official image](https://hub.docker.com/_/traefik), minimize maintenance cost for project maintainers. (Resolves #131)
2. Much simpler setup process for users. `docker compose up -d` is all we need.
3. Safer default settings. Using wildcard DNS for proxy access protect server from malicious scanners. The domain name defaults to `whatsapp-<host-ip>.traefik.me` but easy configurable, user can change to `whatever-<host-ip>.other-wildcard-dns.provider` even their own domain names. 
The domain name is essentially **the password** for accessing the proxy, while others can only see an empty 404 page, which resolves #16, also resolves #120. The only server fingerprint is the default TLS certificate which only indicate it being a traefik server but not whatsapp proxy server. and it can also be further anonymized easily
the server name setting can even be hot reloaded (a traefik feature😉) 
4. Easier co-existance with other web services on same server, saving precious 80/443 ports. Traefik is a container-native edge router (a reverse proxy) which is much much simpler to manage than nginx/haproxy if all your services are running in docker.
5. One-click ACME setup. The necessary config blocks are provided as comments inside `traefik.toml` and `whatsapp_proxy.toml`. However the certificate is not very important because WhatsApp client does not verify this certificate, and medias are sent with TLS passthrough, the connection of which is already secure.

I'd recommend Traefik to be the default option for average users, but let it be an alternative for now 😉