### PR TITLE
Add <1024 port privileges for Helm

### DIFF
--- a/charts/whatsapp-proxy-chart/Chart.yaml
+++ b/charts/whatsapp-proxy-chart/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/whatsapp-proxy-chart/values.yaml
+++ b/charts/whatsapp-proxy-chart/values.yaml
@@ -32,8 +32,12 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
   # fsGroup: 2000
+  sysctls:
+  - name: net.ipv4.ip_unprivileged_port_start
+    value: "0"
+
 
 securityContext: {}
   # capabilities:


### PR DESCRIPTION
Since ports 80, 443, and 587 are used in the config https://github.com/WhatsApp/proxy/blob/2ea2f1fee80a065a4600ac43e3dec0f659e1c7df/proxy/src/proxy_config.cfg#L60
the default Helm chart will refuse to start haproxy on most Kubernetes instances out of the box. This is a known issue with https://github.com/WhatsApp/proxy/issues/110.

For linux Kube clusters > 1.22 we can delegate it with the *safe* sysctl setting `net.ipv4.ip_unprivileged_port_start`: https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/