### PR TITLE
Add New Port Mappings for Helm chart

### DIFF
--- a/.github/workflows/docker-build-pr.yml
+++ b/.github/workflows/docker-build-pr.yml
@@ -1,7 +1,5 @@
 name: Docker Image Build for PRs
 
-# Run on every push to main + weekly, Sunday @ midnight
-# to keep the image fresh
 on:
   pull_request:
     types: [opened, reopened, sychronize]

--- a/.github/workflows/docker-build-pr.yml
+++ b/.github/workflows/docker-build-pr.yml
@@ -1,17 +1,13 @@
-name: Docker Build and PR for Main
+name: Docker Image Build for PRs
 
 # Run on every push to main + weekly, Sunday @ midnight
 # to keep the image fresh
 on:
-  push:
-    branches: [ "main" ]
-  schedule:
-    - cron: "0 0 * * 0"
+  pull_request:
+    types: [opened, reopened, sychronize]
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -31,18 +27,12 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
-    - name: Login to dockerhub
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-    - name: Build and push
+    - name: Build PR
       uses: docker/build-push-action@v3
       with:
         context: ./proxy
         platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
-        push: ${{ github.event_name != 'pull_request' }}
+        push: false
         tags: |
           ${{ steps.meta.outputs.tags }}
           facebook/whatsapp_proxy:latest

--- a/charts/whatsapp-proxy-chart/Chart.yaml
+++ b/charts/whatsapp-proxy-chart/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/whatsapp-proxy-chart/templates/service.yaml
+++ b/charts/whatsapp-proxy-chart/templates/service.yaml
@@ -68,7 +68,7 @@ spec:
     {{- if .Values.service.media_proxy_port }}
     - port: {{ .Values.service.media_proxy_port }}
       targetPort: 7777
-      protocl: TCP
+      protocol: TCP
       name: media
     {{- end}}
 

--- a/charts/whatsapp-proxy-chart/templates/service.yaml
+++ b/charts/whatsapp-proxy-chart/templates/service.yaml
@@ -54,9 +54,24 @@ spec:
     {{- end}}
     {{- if .Values.service.stats_port }}
     - port: {{ .Values.service.stats_port }}
-      targetPort: {{ .Values.service.stats_port }}
+      targetPort: 8199
       protocol: TCP
       name: stats
     {{- end}}
+    {{- if .Values.service.media_port }}
+    - port: {{ .Values.service.media_port }}
+      targetPort: 587
+      protocl: TCP
+      name: media
+    {{- end}}
+
+    {{- if .Values.service.media_proxy_port }}
+    - port: {{ .Values.service.media_proxy_port }}
+      targetPort: 7777
+      protocl: TCP
+      name: media
+    {{- end}}
+
+
   selector:
     {{- include "whatsapp-proxy-chart.selectorLabels" . | nindent 4 }}

--- a/charts/whatsapp-proxy-chart/templates/service.yaml
+++ b/charts/whatsapp-proxy-chart/templates/service.yaml
@@ -61,7 +61,7 @@ spec:
     {{- if .Values.service.media_port }}
     - port: {{ .Values.service.media_port }}
       targetPort: 587
-      protocl: TCP
+      protocol: TCP
       name: media
     {{- end}}
 

--- a/charts/whatsapp-proxy-chart/values.yaml
+++ b/charts/whatsapp-proxy-chart/values.yaml
@@ -49,7 +49,8 @@ securityContext: {}
 
 service:
   type: LoadBalancer
-  annotations: {}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   port: 8080
   http_port: 80
   https_port: 443

--- a/charts/whatsapp-proxy-chart/values.yaml
+++ b/charts/whatsapp-proxy-chart/values.yaml
@@ -48,15 +48,17 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
-  type: ClusterIP
+  type: LoadBalancer
   annotations: {}
   port: 8080
-  # http_port: 80
-  # https_port: 443
-  # jabber_port: 5222
-  http_proxy_port: 8080
-  https_proxy_port: 8443
-  jabber_proxy_port: 8222
+  http_port: 80
+  https_port: 443
+  jabber_port: 5222
+  media_port: 587
+  # http_proxy_port: 8080
+  # https_proxy_port: 8443
+  # jabber_proxy_port: 8222
+  # media_proxy_port: 7777
   # stats_port: 8199
 
 ingress:


### PR DESCRIPTION
- The stats port `8199` is open by default, and it should probably be closed. 

- Media ports are not open by default on the helm chart, fixes that

- Changes the service type to an external load balancer type so that a default helm deployment creates an external IP.

- Also fixes the docker build pipeline for PRs to only build, and not push