### PR TITLE
Fix HPA Template & Add Media Proxy Ports

### DIFF
--- a/charts/whatsapp-proxy-chart/Chart.yaml
+++ b/charts/whatsapp-proxy-chart/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/whatsapp-proxy-chart/templates/deployment.yaml
+++ b/charts/whatsapp-proxy-chart/templates/deployment.yaml
@@ -68,6 +68,16 @@ spec:
               containerPort: 5222
               protocol: TCP
             {{- end}}
+            {{- if .Values.service.media_port }}
+            - name: media
+              containerPort: 587
+              protocol: TCP
+            {{- end}}
+            {{- if .Values.service.media_proxy_port}}
+            - name: media-proxy
+              containerPort: 7777
+              protocol: TCP
+            {{- end}}
             {{- if .Values.service.stats_port }}
             - name: stats
               containerPort: 8199

--- a/charts/whatsapp-proxy-chart/templates/hpa.yaml
+++ b/charts/whatsapp-proxy-chart/templates/hpa.yaml
@@ -3,7 +3,7 @@
 # License found in the LICENSE file in the root directory
 # of this source tree.
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "whatsapp-proxy-chart.fullname" . }}
@@ -21,12 +21,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/charts/whatsapp-proxy-chart/templates/service.yaml
+++ b/charts/whatsapp-proxy-chart/templates/service.yaml
@@ -64,7 +64,6 @@ spec:
       protocol: TCP
       name: media
     {{- end}}
-
     {{- if .Values.service.media_proxy_port }}
     - port: {{ .Values.service.media_proxy_port }}
       targetPort: 7777


### PR DESCRIPTION
The HPA template was still using `apiVersion: autoscaling/v2beta1`, which has long been deprecated. Updating it to fix the syntax, as well as pass down the media proxy port.