### PR TITLE
Add prometheus integration with ServiceMonitor CRD

### DIFF
--- a/charts/whatsapp-proxy-chart/Chart.yaml
+++ b/charts/whatsapp-proxy-chart/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/whatsapp-proxy-chart/templates/servicemonitor.yaml
+++ b/charts/whatsapp-proxy-chart/templates/servicemonitor.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# License found in the LICENSE file in the root directory
+# of this source tree.
+{{- if .Values.enableServiceMonitor }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "whatsapp-proxy-chart.fullname" . }}-servicemonitor
+  namespace: default
+  labels:
+    release: {{ .Values.prometheus.release }}
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: stats
+  namespaceSelector:
+    matchNames:
+    - default
+  selector:
+    matchLabels:
+      {{- include "whatsapp-proxy-chart.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/whatsapp-proxy-chart/values.yaml
+++ b/charts/whatsapp-proxy-chart/values.yaml
@@ -102,3 +102,8 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Enables service monitor for the prometheus operator.
+enableServiceMonitor: false
+prometheus:
+  release: my-prometheus-release


### PR DESCRIPTION
Adds a ServiceMonitor for HAProxy (https://observability.thomasriley.co.uk/prometheus/configuring-prometheus/using-service-monitors/). 

Off by default, can be enabled by users as needed.