### PR TITLE
Correct typos and improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To confirm HAProxy is running, visit `http://<host-ip>:8199` where `<host-ip>` i
 
 If you prefer OpenMetrics output you can use `http://<host-ip>:8199/metrics` for monitoring HAProxy metrics.
 
-# Miscellanous
+# Miscellaneous
 
 ## An Overview of the WhatsApp Proxy Architecture
 

--- a/proxy/src/generate-certs.sh
+++ b/proxy/src/generate-certs.sh
@@ -36,7 +36,7 @@ if [[ -e ./${CA_KEY} ]]; then
     echo "====> Using existing CA Key ${CA_KEY}"
 else
     echo "====> Generating new CA key ${CA_KEY}"
-    openssl genrsa -out ${CA_KEY} 4096
+    openssl genrsa -out ${CA_KEY} 4096 || exit 1
 fi
 
 if [[ -e ./${CA_CERT} ]]; then
@@ -59,24 +59,32 @@ basicConstraints = CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth, serverAuth
 EOM
+if [ $? -ne 0 ]; then
+    echo "ERROR: Failed to create SSL config file ${SSL_CONFIG}" >&2
+    exit 1
+fi
 
 if [[ -n ${SSL_DNS} || -n ${SSL_IP} ]]; then
     cat >> ${SSL_CONFIG} <<EOM
 subjectAltName = @alt_names
 [alt_names]
 EOM
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Failed to append to SSL config file ${SSL_CONFIG}" >&2
+        exit 1
+    fi
 
     IFS=","
     dns=(${SSL_DNS})
     dns+=(${SSL_SUBJECT})
     for i in "${!dns[@]}"; do
-      echo DNS.$((i+1)) = ${dns[$i]} >> ${SSL_CONFIG}
+      echo DNS.$((i+1)) = ${dns[$i]} >> ${SSL_CONFIG} || exit 1
     done
 
     if [[ -n ${SSL_IP} ]]; then
         ip=(${SSL_IP})
         for i in "${!ip[@]}"; do
-          echo IP.$((i+1)) = ${ip[$i]} >> ${SSL_CONFIG}
+          echo IP.$((i+1)) = ${ip[$i]} >> ${SSL_CONFIG} || exit 1
         done
     fi
 fi
@@ -92,8 +100,8 @@ openssl x509 -req -in ${SSL_CSR} -CA ${CA_CERT} -CAkey ${CA_KEY} -CAcreateserial
     -days ${SSL_EXPIRE} -extensions v3_req -extfile ${SSL_CONFIG}  || exit 1
 
 echo "====> Generating SSL CERT / KEY COMBO proxy.whatsapp.net.pem"
-cat ${SSL_KEY} > proxy.whatsapp.net.pem
-cat ${SSL_CERT} >> proxy.whatsapp.net.pem
+cat ${SSL_KEY} > proxy.whatsapp.net.pem || exit 1
+cat ${SSL_CERT} >> proxy.whatsapp.net.pem || exit 1
 
 echo "Certificate generation completed."
 

--- a/proxy/src/healthcheck.sh
+++ b/proxy/src/healthcheck.sh
@@ -19,8 +19,8 @@ RESULT=$(tail -n +1 /tmp/stats.txt | jq -R 'split(",")' | jq -c 'select(.[1] != 
 if [ "$RESULT" != "" ]
 then
   echo "[HEALTHCHECKER] Container failed healthchecks, L4 healthcheck on *.whatsapp.net failed"
-  echo "[HEALTKCHECKER] Result $RESULT"
-  exit -1;
+  echo "[HEALTHCHECKER] Result $RESULT"
+  exit 1
 fi
 
 exit 0;

--- a/proxy/src/set_public_ip_and_start.sh
+++ b/proxy/src/set_public_ip_and_start.sh
@@ -15,7 +15,7 @@
 CONFIG_FILE="/usr/local/etc/haproxy/haproxy.cfg"
 
 ## Custom function to use as curl wrapper
-# --silent: to reduce the nois eof response
+# --silent: to reduce the noise of response
 # --show-error: to show errors in the response
 # --fail: to fail on non-200 responses
 # --ipv4: to force ipv4 resolution
@@ -69,16 +69,37 @@ then
     # haproxy configuration statement for the frontend which set's the destination
     # ip to the public ip of the container (which is necessary to determine our IP's
     # internally within WA)
-    sed -i "s/#PUBLIC\_IP/tcp-request connection set-dst ipv4($PUBLIC_IP)/g" $CONFIG_FILE
+    sed -i "s/#PUBLIC\_IP/tcp-request connection set-dst ipv4($PUBLIC_IP)/g" $CONFIG_FILE || {
+        echo "[PROXYHOST] ERROR: Failed to update HAProxy configuration with public IP" >&2
+        exit 1
+    }
 fi
 
 # Setup a new, on-the-fly certificate for the HTTPS port (so this re-generates each restart)
-pushd /home/haproxy/certs
-/usr/local/bin/generate-certs.sh
-mv proxy.whatsapp.net.pem /etc/haproxy/ssl/proxy.whatsapp.net.pem
-chown haproxy:haproxy /etc/haproxy/ssl/proxy.whatsapp.net.pem
+pushd /home/haproxy/certs || {
+    echo "[PROXYHOST] ERROR: Failed to change to /home/haproxy/certs directory" >&2
+    exit 1
+}
+/usr/local/bin/generate-certs.sh || {
+    echo "[PROXYHOST] ERROR: Certificate generation failed" >&2
+    popd
+    exit 1
+}
+mv proxy.whatsapp.net.pem /etc/haproxy/ssl/proxy.whatsapp.net.pem || {
+    echo "[PROXYHOST] ERROR: Failed to move certificate to /etc/haproxy/ssl/" >&2
+    popd
+    exit 1
+}
+chown haproxy:haproxy /etc/haproxy/ssl/proxy.whatsapp.net.pem || {
+    echo "[PROXYHOST] ERROR: Failed to set certificate ownership" >&2
+    popd
+    exit 1
+}
 popd
 
 # Start HAProxy
-haproxy -f "$CONFIG_FILE"
+haproxy -f "$CONFIG_FILE" || {
+    echo "[PROXYHOST] ERROR: HAProxy failed to start" >&2
+    exit 1
+}
 


### PR DESCRIPTION
This PR fixes typos and adds comprehensive error handling to shell scripts to prevent silent failures and improve maintainability.

### Error Handling in `set_public_ip_and_start.sh`

**Before** (silent failure risk):
```bash
# Setup a new, on-the-fly certificate for the HTTPS port
pushd /home/haproxy/certs
/usr/local/bin/generate-certs.sh
mv proxy.whatsapp.net.pem /etc/haproxy/ssl/proxy.whatsapp.net.pem
chown haproxy:haproxy /etc/haproxy/ssl/proxy.whatsapp.net.pem
popd

# Start HAProxy
haproxy -f "$CONFIG_FILE"
```

**After** (with error handling):
```bash
# Setup a new, on-the-fly certificate for the HTTPS port
pushd /home/haproxy/certs || {
    echo "[PROXYHOST] ERROR: Failed to change to /home/haproxy/certs directory" >&2
    exit 1
}
/usr/local/bin/generate-certs.sh || {
    echo "[PROXYHOST] ERROR: Certificate generation failed" >&2
    popd
    exit 1
}
mv proxy.whatsapp.net.pem /etc/haproxy/ssl/proxy.whatsapp.net.pem || {
    echo "[PROXYHOST] ERROR: Failed to move certificate to /etc/haproxy/ssl/" >&2
    popd
    exit 1
}
chown haproxy:haproxy /etc/haproxy/ssl/proxy.whatsapp.net.pem || {
    echo "[PROXYHOST] ERROR: Failed to set certificate ownership" >&2
    popd
    exit 1
}
popd

# Start HAProxy
haproxy -f "$CONFIG_FILE" || {
    echo "[PROXYHOST] ERROR: HAProxy failed to start" >&2
    exit 1
}
```

### Error Handling in `generate-certs.sh`

**Before** (missing error check):
```bash
if [[ -e ./${CA_KEY} ]]; then
    echo "====> Using existing CA Key ${CA_KEY}"
else
    echo "====> Generating new CA key ${CA_KEY}"
    openssl genrsa -out ${CA_KEY} 4096
fi
```

**After** (with error check):
```bash
if [[ -e ./${CA_KEY} ]]; then
    echo "====> Using existing CA Key ${CA_KEY}"
else
    echo "====> Generating new CA key ${CA_KEY}"
    openssl genrsa -out ${CA_KEY} 4096 || exit 1
fi
```

### Exit Code Fix in `healthcheck.sh`

**Before** (non-standard exit code):
```bash
if [ "$RESULT" != "" ]
then
  echo "[HEALTHCHECKER] Container failed healthchecks, L4 healthcheck on *.whatsapp.net failed"
  echo "[HEALTKCHECKER] Result $RESULT"
  exit -1;
fi
```

**After** (standard exit code + typo fix):
```bash
if [ "$RESULT" != "" ]
then
  echo "[HEALTHCHECKER] Container failed healthchecks, L4 healthcheck on *.whatsapp.net failed"
  echo "[HEALTHCHECKER] Result $RESULT"
  exit 1
fi
```


