### PR TITLE
Mount HAProxy config via ConfigMap instead of baking into image

### DIFF
--- a/charts/whatsapp-proxy-chart/Chart.yaml
+++ b/charts/whatsapp-proxy-chart/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/whatsapp-proxy-chart/templates/configmap.yaml
+++ b/charts/whatsapp-proxy-chart/templates/configmap.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# License found in the LICENSE file in the root directory
+# of this source tree.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "whatsapp-proxy-chart.fullname" . }}-haproxy
+  labels:
+    {{- include "whatsapp-proxy-chart.labels" . | nindent 4 }}
+data:
+  haproxy.cfg: |
+    {{- .Values.haproxyConfig | nindent 4 }}

--- a/charts/whatsapp-proxy-chart/templates/deployment.yaml
+++ b/charts/whatsapp-proxy-chart/templates/deployment.yaml
@@ -17,10 +17,11 @@ spec:
       {{- include "whatsapp-proxy-chart.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/haproxy-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "whatsapp-proxy-chart.selectorLabels" . | nindent 8 }}
     spec:
@@ -94,6 +95,15 @@ spec:
           env:
             - name: "PUBLIC_IP"
               value: "{{ .Values.public_ip }}"
+          volumeMounts:
+            - name: haproxy-config
+              mountPath: /usr/local/etc/haproxy/haproxy.cfg
+              subPath: haproxy.cfg
+              readOnly: true
+      volumes:
+        - name: haproxy-config
+          configMap:
+            name: {{ include "whatsapp-proxy-chart.fullname" . }}-haproxy
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/whatsapp-proxy-chart/values.yaml
+++ b/charts/whatsapp-proxy-chart/values.yaml
@@ -102,3 +102,75 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# HAProxy configuration file contents.
+# Edit this to customize proxy behavior without rebuilding the image.
+haproxyConfig: |
+  global
+    tune.bufsize 4096
+    maxconn 27500
+    spread-checks 5
+    ssl-server-verify none
+
+  defaults
+    mode tcp
+    timeout client-fin 1s
+    timeout server-fin 1s
+    timeout connect 5s
+    timeout client 200s
+    timeout server 200s
+    default-server inter 10s fastinter 1s downinter 3s error-limit 50
+
+  listen stats
+    bind :::8199
+    mode http
+    http-request use-service prometheus-exporter if { path /metrics }
+    stats uri /
+
+  frontend haproxy_v4_http
+    maxconn 27495
+    #PUBLIC_IP
+
+    bind ipv4@*:80
+    bind ipv4@*:8080 accept-proxy
+
+    default_backend wa_http
+
+  frontend haproxy_v4_https
+    maxconn 27495
+    #PUBLIC_IP
+
+    bind ipv4@*:443 ssl crt /etc/haproxy/ssl/proxy.whatsapp.net.pem
+    bind ipv4@*:8443 ssl crt /etc/haproxy/ssl/proxy.whatsapp.net.pem accept-proxy
+
+    default_backend wa
+
+  frontend haproxy_v4_xmpp
+    maxconn 27495
+    #PUBLIC_IP
+
+    bind ipv4@*:5222
+    bind ipv4@*:8222 accept-proxy
+
+    default_backend wa
+
+  frontend haproxy_v4_whatsapp_net
+    maxconn 27495
+    #PUBLIC_IP
+
+    bind ipv4@*:587
+    bind ipv4@*:7777
+
+    default_backend wa_whatsapp_net
+
+  backend wa_whatsapp_net
+    default-server check inter 60000 observe layer4
+    server whatsapp_net_443 whatsapp.net:443
+
+  backend wa
+    default-server check inter 60000 observe layer4 send-proxy
+    server g_whatsapp_net_5222 g.whatsapp.net:5222
+
+  backend wa_http
+    default-server check inter 60000 observe layer4 send-proxy
+    server g_whatsapp_net_80 g.whatsapp.net:80


### PR DESCRIPTION
Externalizes the HAProxy configuration so it can be managed via Helm values without rebuilding the Docker image. Adds a checksum annotation to trigger rolling restarts on config changes.