### PR TITLE
Add loadBalancerClass support to service template

### DIFF
--- a/charts/whatsapp-proxy-chart/Chart.yaml
+++ b/charts/whatsapp-proxy-chart/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.1
+version: 1.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/whatsapp-proxy-chart/templates/service.yaml
+++ b/charts/whatsapp-proxy-chart/templates/service.yaml
@@ -15,6 +15,9 @@ metadata:
 
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{ . | quote }}
+  {{- end }}
   ports:
     {{- if .Values.service.http_proxy_port }}
     - port: {{ .Values.service.http_proxy_port }}


### PR DESCRIPTION

Summary: Allow specifying a loadBalancerClass on the proxy Service via
`.Values.service.loadBalancerClass`. When set, it is rendered onto the
Service spec; when unset, the field is omitted so default behavior is
preserved.

Test Plan: helm template / lint the chart with and without
service.loadBalancerClass set and confirm the field renders only when
provided.
