### PR TITLE
Support extra volumes and volumeMounts in proxy deployment (v1.3.4)

### DIFF
--- a/charts/whatsapp-proxy-chart/Chart.yaml
+++ b/charts/whatsapp-proxy-chart/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.3
+version: 1.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/whatsapp-proxy-chart/templates/deployment.yaml
+++ b/charts/whatsapp-proxy-chart/templates/deployment.yaml
@@ -124,12 +124,18 @@ spec:
             # at its canonical /usr/local/etc/haproxy/haproxy.cfg location.
             - name: haproxy-config
               mountPath: /usr/local/etc/haproxy
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: haproxy-config-src
           configMap:
             name: {{ include "whatsapp-proxy-chart.fullname" . }}-haproxy
         - name: haproxy-config
           emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/whatsapp-proxy-chart/values.yaml
+++ b/charts/whatsapp-proxy-chart/values.yaml
@@ -103,6 +103,13 @@ tolerations: []
 
 affinity: {}
 
+# Extra volumes to attach to the pod, rendered as-is into the Deployment's
+# spec.template.spec.volumes
+extraVolumes: []
+
+# Extra volumeMounts for the HAProxy container.
+extraVolumeMounts: []
+
 # HAProxy tunables. These are interpolated into haproxyConfig below via `tpl`,
 # so individual values (e.g. maxconn) can be overridden per-deployment without
 # replacing the entire config blob.


### PR DESCRIPTION

Add generic extraVolumes / extraVolumeMounts passthroughs to the
whatsapp-proxy-chart Deployment so externally-provisioned resources
(e.g. a TLS client certificate secret for upstream mTLS) can be
attached without modifying the chart templates.

Both default to empty lists, so rendered output is unchanged unless
explicitly set. Bump chart version 1.3.3 -> 1.3.4.
