### PR TITLE
Fix HPA utilization calc by removing labels from test pod

### DIFF
--- a/charts/whatsapp-proxy-chart/Chart.yaml
+++ b/charts/whatsapp-proxy-chart/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.4
+version: 1.3.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/whatsapp-proxy-chart/templates/tests/test-connection.yaml
+++ b/charts/whatsapp-proxy-chart/templates/tests/test-connection.yaml
@@ -6,10 +6,12 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "whatsapp-proxy-chart.fullname" . }}-test-connection"
-  labels:
-    {{- include "whatsapp-proxy-chart.labels" . | nindent 4 }}
+  # Intentionally omit common/selector labels so this pod is not matched by the
+  # HPA's selector. This test pod has no resource requests, and including it
+  # would break the HPA's utilization calculation.
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   containers:
     - name: wget


### PR DESCRIPTION

Summary:
The Helm test-connection pod inherited the chart's common/selector labels,
which caused it to be matched by the HPA's selector. Since the test pod has
no resource requests, its inclusion broke the HPA's CPU/memory utilization
calculation.

This removes the labels from the test pod (with a comment explaining why),
and adds a hook-delete-policy so the pod is cleaned up after a successful
test run.

Test Plan:
- helm template renders the test pod without labels
- helm test creates the pod, and it is deleted on success
