### PR TITLE
Add optional ServiceMonitor for HAProxy Prometheus metrics (v1.3.6)

### DIFF
--- a/charts/whatsapp-proxy-chart/Chart.yaml
+++ b/charts/whatsapp-proxy-chart/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.5
+version: 1.3.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/whatsapp-proxy-chart/templates/servicemonitor.yaml
+++ b/charts/whatsapp-proxy-chart/templates/servicemonitor.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# License found in the LICENSE file in the root directory
+# of this source tree.
+{{- if .Values.enableServiceMonitor }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "whatsapp-proxy-chart.fullname" . }}-servicemonitor
+  namespace: default
+  labels:
+    release: {{ .Values.prometheus.release }}
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: stats
+  namespaceSelector:
+    matchNames:
+    - default
+  selector:
+    matchLabels:
+      {{- include "whatsapp-proxy-chart.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/whatsapp-proxy-chart/values.yaml
+++ b/charts/whatsapp-proxy-chart/values.yaml
@@ -110,6 +110,10 @@ extraVolumes: []
 # Extra volumeMounts for the HAProxy container.
 extraVolumeMounts: []
 
+enableServiceMonitor: false
+prometheus:
+  release: my-prometheus-release
+
 # HAProxy tunables. These are interpolated into haproxyConfig below via `tpl`,
 # so individual values (e.g. maxconn) can be overridden per-deployment without
 # replacing the entire config blob.


### PR DESCRIPTION

Add a ServiceMonitor template (Prometheus Operator / kube-prometheus-stack)
so HAProxy's native Prometheus exporter on the stats port (/metrics) can be
scraped. Gated behind enableServiceMonitor (default false) with a configurable
prometheus.release label for monitor discovery. Bump chart version to 1.3.6.
