### PR TITLE
Add customMetrics support to HPA autoscaling

### DIFF
--- a/charts/whatsapp-proxy-chart/Chart.yaml
+++ b/charts/whatsapp-proxy-chart/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.6
+version: 1.3.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/whatsapp-proxy-chart/templates/hpa.yaml
+++ b/charts/whatsapp-proxy-chart/templates/hpa.yaml
@@ -33,4 +33,7 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+    {{- with .Values.autoscaling.customMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/whatsapp-proxy-chart/values.yaml
+++ b/charts/whatsapp-proxy-chart/values.yaml
@@ -96,6 +96,7 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+  customMetrics: []
 
 nodeSelector: {}
 


### PR DESCRIPTION

Summary:
Adds a configurable `customMetrics` list to the WhatsApp proxy chart's
autoscaling values, rendered into the HPA template's metrics section.
This allows defining custom autoscaling metrics beyond CPU/memory.

Test Plan:
- helm template renders with default (empty) customMetrics
- helm template renders custom metrics when provided