### PR TITLE
Avoid proxy rollouts on chart metadata changes

### DIFF
--- a/charts/whatsapp-proxy-chart/Chart.yaml
+++ b/charts/whatsapp-proxy-chart/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.9
+version: 1.3.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/whatsapp-proxy-chart/templates/deployment.yaml
+++ b/charts/whatsapp-proxy-chart/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/haproxy-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/haproxy-config: {{ tpl .Values.haproxyConfig . | sha256sum }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
Hash only the rendered HAProxy configuration for the pod-template checksum instead of the entire ConfigMap manifest. This prevents chart label and other metadata-only changes from triggering a Deployment rollout.