### PR TITLE
Send PROXY protocol v2 to backends by default

### DIFF
--- a/charts/whatsapp-proxy-chart/Chart.yaml
+++ b/charts/whatsapp-proxy-chart/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.10
+version: 1.3.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/whatsapp-proxy-chart/values.yaml
+++ b/charts/whatsapp-proxy-chart/values.yaml
@@ -172,7 +172,7 @@ haproxy:
       serverName: whatsapp_net_443
       serverAddress: whatsapp.net:443
     wa:
-      defaultServer: check inter 60000 observe layer4 send-proxy
+      defaultServer: check inter 60000 observe layer4 send-proxy-v2
       servers:
         - name: g_whatsapp_net_5222
           address: g.whatsapp.net:5222


### PR DESCRIPTION

Summary:
- Configure the `wa` backend to use `send-proxy-v2`.
- Bump the Helm chart version to `1.3.11`.

Test Plan:
- `helm lint charts/whatsapp-proxy-chart`
- `helm template test-release charts/whatsapp-proxy-chart` (verified the rendered backend uses `send-proxy-v2`)
