### PR TITLE
Remove public IP rewriting from Helm chart

### DIFF
--- a/charts/whatsapp-proxy-chart/Chart.yaml
+++ b/charts/whatsapp-proxy-chart/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.11
+version: 1.3.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/whatsapp-proxy-chart/templates/deployment.yaml
+++ b/charts/whatsapp-proxy-chart/templates/deployment.yaml
@@ -32,29 +32,6 @@ spec:
       serviceAccountName: {{ include "whatsapp-proxy-chart.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      initContainers:
-        # The container entrypoint substitutes #PUBLIC_IP -> `set-dst` in
-        # /usr/local/etc/haproxy/haproxy.cfg in place. A ConfigMap volume is
-        # always mounted read-only by the kubelet (the readOnly flag can't
-        # change that), which makes that in-place edit fail and leaves HAProxy
-        # advertising the pod's private IP. So seed a writable emptyDir with the
-        # image defaults (e.g. errors/) and overlay the ConfigMap haproxy.cfg.
-        - name: haproxy-config-init
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - /bin/sh
-            - -c
-            - |
-              set -e
-              cp -a /usr/local/etc/haproxy/. /haproxy-runtime/
-              cp /haproxy-config-src/haproxy.cfg /haproxy-runtime/haproxy.cfg
-          volumeMounts:
-            - name: haproxy-config-src
-              mountPath: /haproxy-config-src
-              readOnly: true
-            - name: haproxy-config
-              mountPath: /haproxy-runtime
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -115,27 +92,22 @@ spec:
             periodSeconds: 30
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.extraEnv }}
           env:
-            - name: "PUBLIC_IP"
-              value: "{{ .Values.public_ip }}"
-            {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
-            {{- end }}
+          {{- end }}
           volumeMounts:
-            # Writable copy of the config dir (populated by the initContainer)
-            # so the entrypoint can edit haproxy.cfg in place, while keeping it
-            # at its canonical /usr/local/etc/haproxy/haproxy.cfg location.
             - name: haproxy-config
-              mountPath: /usr/local/etc/haproxy
+              mountPath: /usr/local/etc/haproxy/haproxy.cfg
+              subPath: haproxy.cfg
+              readOnly: true
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
-        - name: haproxy-config-src
+        - name: haproxy-config
           configMap:
             name: {{ include "whatsapp-proxy-chart.fullname" . }}-haproxy
-        - name: haproxy-config
-          emptyDir: {}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/whatsapp-proxy-chart/values.yaml
+++ b/charts/whatsapp-proxy-chart/values.yaml
@@ -15,8 +15,6 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
 
-public_ip: "10.0.0.1"
-
 imagePullSecrets: {}
 nameOverride: ""
 fullnameOverride: ""
@@ -214,7 +212,6 @@ haproxyConfig: |
 
   frontend haproxy_v4_http
     maxconn {{ .Values.haproxy.frontends.haproxyV4Http.maxconn }}
-    #PUBLIC_IP
 
     bind {{ .Values.haproxy.frontends.haproxyV4Http.directBind }}
     bind {{ .Values.haproxy.frontends.haproxyV4Http.proxyBind }}
@@ -226,7 +223,6 @@ haproxyConfig: |
 
   frontend haproxy_v4_https
     maxconn {{ .Values.haproxy.frontends.haproxyV4Https.maxconn }}
-    #PUBLIC_IP
 
     bind {{ .Values.haproxy.frontends.haproxyV4Https.directBind }}
     bind {{ .Values.haproxy.frontends.haproxyV4Https.proxyBind }}
@@ -238,7 +234,6 @@ haproxyConfig: |
 
   frontend haproxy_v4_xmpp
     maxconn {{ .Values.haproxy.frontends.haproxyV4Xmpp.maxconn }}
-    #PUBLIC_IP
 
     bind {{ .Values.haproxy.frontends.haproxyV4Xmpp.directBind }}
     bind {{ .Values.haproxy.frontends.haproxyV4Xmpp.proxyBind }}
@@ -250,7 +245,6 @@ haproxyConfig: |
 
   frontend haproxy_v4_whatsapp_net
     maxconn {{ .Values.haproxy.frontends.haproxyV4WhatsappNet.maxconn }}
-    #PUBLIC_IP
 
     bind {{ .Values.haproxy.frontends.haproxyV4WhatsappNet.directBind }}
     bind {{ .Values.haproxy.frontends.haproxyV4WhatsappNet.proxyBind }}


### PR DESCRIPTION

Summary:
- remove the `PUBLIC_IP` setting and HAProxy placeholder directives
- mount the generated HAProxy configuration directly as a read-only file
- remove the writable configuration init container
- bump the chart version to `1.3.12`

Test Plan:
- `helm lint charts/whatsapp-proxy-chart`
- `helm template test charts/whatsapp-proxy-chart`
- `git diff --check`
