### PR TITLE
Declare all HAProxy container ports unconditionally

### DIFF
--- a/charts/whatsapp-proxy-chart/Chart.yaml
+++ b/charts/whatsapp-proxy-chart/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.12
+version: 1.3.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/whatsapp-proxy-chart/templates/deployment.yaml
+++ b/charts/whatsapp-proxy-chart/templates/deployment.yaml
@@ -39,51 +39,33 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            {{- if .Values.service.http_proxy_port }}
             - name: http-proxy
               containerPort: 8080
               protocol: TCP
-            {{- end}}
-            {{- if .Values.service.http_port }}
             - name: http
               containerPort: 80
               protocol: TCP
-            {{- end}}
-            {{- if .Values.service.https_proxy_port }}
             - name: https-proxy
               containerPort: 8443
               protocol: TCP
-            {{- end}}
-            {{- if .Values.service.https_port }}
             - name: https
               containerPort: 443
               protocol: TCP
-            {{- end}}
-            {{- if .Values.service.jabber_proxy_port }}
             - name: jabber-proxy
               containerPort: 8222
               protocol: TCP
-            {{- end}}
-            {{- if .Values.service.jabber_port }}
             - name: jabber
               containerPort: 5222
               protocol: TCP
-            {{- end}}
-            {{- if .Values.service.media_port }}
             - name: media
               containerPort: 587
               protocol: TCP
-            {{- end}}
-            {{- if .Values.service.media_proxy_port}}
             - name: media-proxy
               containerPort: 7777
               protocol: TCP
-            {{- end}}
-            {{- if .Values.service.stats_port }}
             - name: stats
               containerPort: 8199
               protocol: TCP
-            {{- end}}
           readinessProbe:
             exec:
               command:


### PR DESCRIPTION
- Always declare every port listened on by HAProxy in the container spec.
- Keep service port configuration limited to controlling `Service` exposure, since omitting a `containerPort` does not prevent other pods from connecting, but serves as metadata and port names for `Service` resources