### PR TITLE
Move stats port to separate internal Service

### DIFF
--- a/charts/whatsapp-proxy-chart/Chart.yaml
+++ b/charts/whatsapp-proxy-chart/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.13
+version: 1.3.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/whatsapp-proxy-chart/deployments/README.md
+++ b/charts/whatsapp-proxy-chart/deployments/README.md
@@ -316,8 +316,9 @@ The output should look like the following:
 
 ```
 NAME                                  TYPE           CLUSTER-IP    EXTERNAL-IP   PORT(S)                                                                                                 AGE
-kubernetes                            ClusterIP      10.72.0.1     <none>        443/TCP                                                                                                 19h
-whatsapp-proxy-whatsapp-proxy-chart   LoadBalancer   10.72.2.240   <PUBLIC_ENDPOINT>     8080:32220/TCP,8443:32287/TCP,8222:30054/TCP,5222:32734/TCP,80:31717/TCP,443:32498/TCP,8199:30617/TCP   3s
+kubernetes                                    ClusterIP      10.72.0.1     <none>              443/TCP                                                                                           19h
+whatsapp-proxy-whatsapp-proxy-chart           LoadBalancer   10.72.2.240   <PUBLIC_ENDPOINT>   8080:32220/TCP,8443:32287/TCP,8222:30054/TCP,5222:32734/TCP,80:31717/TCP,443:32498/TCP   3s
+whatsapp-proxy-whatsapp-proxy-chart-metrics   ClusterIP      10.72.2.241   <none>              8199/TCP                                                                                          3s
 ```
 
 The public endpoint for your deployment will appear under EXTERNAL-IP.

--- a/charts/whatsapp-proxy-chart/templates/metrics-service.yaml
+++ b/charts/whatsapp-proxy-chart/templates/metrics-service.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# License found in the LICENSE file in the root directory
+# of this source tree.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "whatsapp-proxy-chart.fullname" . }}-metrics
+  labels:
+    {{- include "whatsapp-proxy-chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+spec:
+  type: ClusterIP
+  ports:
+    - name: stats
+      port: 8199
+      targetPort: stats
+      protocol: TCP
+  selector:
+    {{- include "whatsapp-proxy-chart.selectorLabels" . | nindent 4 }}

--- a/charts/whatsapp-proxy-chart/templates/service.yaml
+++ b/charts/whatsapp-proxy-chart/templates/service.yaml
@@ -55,12 +55,6 @@ spec:
       protocol: TCP
       name: https
     {{- end}}
-    {{- if .Values.service.stats_port }}
-    - port: {{ .Values.service.stats_port }}
-      targetPort: 8199
-      protocol: TCP
-      name: stats
-    {{- end}}
     {{- if .Values.service.media_port }}
     - port: {{ .Values.service.media_port }}
       targetPort: 587

--- a/charts/whatsapp-proxy-chart/templates/servicemonitor.yaml
+++ b/charts/whatsapp-proxy-chart/templates/servicemonitor.yaml
@@ -7,18 +7,15 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "whatsapp-proxy-chart.fullname" . }}-servicemonitor
-  namespace: default
   labels:
     release: {{ .Values.prometheus.release }}
 spec:
   endpoints:
-  - interval: 30s
-    path: /metrics
-    port: stats
-  namespaceSelector:
-    matchNames:
-    - default
+    - interval: 30s
+      path: /metrics
+      port: stats
   selector:
     matchLabels:
+      app.kubernetes.io/component: metrics
       {{- include "whatsapp-proxy-chart.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/charts/whatsapp-proxy-chart/templates/tests/test-connection.yaml
+++ b/charts/whatsapp-proxy-chart/templates/tests/test-connection.yaml
@@ -17,5 +17,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "whatsapp-proxy-chart.fullname" . }}:{{ .Values.service.stats_port }}']
+      args: ['{{ include "whatsapp-proxy-chart.fullname" . }}-metrics:8199{{ .Values.haproxy.stats.metricsPath }}']
   restartPolicy: Never

--- a/charts/whatsapp-proxy-chart/values.yaml
+++ b/charts/whatsapp-proxy-chart/values.yaml
@@ -58,7 +58,6 @@ service:
   # https_proxy_port: 8443
   # jabber_proxy_port: 8222
   # media_proxy_port: 7777
-  # stats_port: 8199
 
 ingress:
   enabled: false


### PR DESCRIPTION

Summary:
As the primary `Service` can be backed by public load balancer, move the stats ports to another `Service` w/ type `ClusterIP`

Test Plan:
- `helm lint charts/whatsapp-proxy-chart`
- `helm template test charts/whatsapp-proxy-chart --set enableServiceMonitor=true`
