### PR TITLE
Support extra init containers in proxy chart

### DIFF
--- a/charts/whatsapp-proxy-chart/Chart.yaml
+++ b/charts/whatsapp-proxy-chart/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.15
+version: 1.3.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/whatsapp-proxy-chart/templates/deployment.yaml
+++ b/charts/whatsapp-proxy-chart/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
       serviceAccountName: {{ include "whatsapp-proxy-chart.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.extraInitContainers }}
+      initContainers:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/whatsapp-proxy-chart/values.yaml
+++ b/charts/whatsapp-proxy-chart/values.yaml
@@ -101,6 +101,10 @@ tolerations: []
 
 affinity: {}
 
+# Extra init containers to run before HAProxy. The rendered YAML supports tpl
+# expressions, including references to the main image repository and tag.
+extraInitContainers: []
+
 # Extra volumes to attach to the pod, rendered as-is into the Deployment's
 # spec.template.spec.volumes
 extraVolumes: []


### PR DESCRIPTION

Summary:
- Add templated `extraInitContainers` support to the WhatsApp proxy chart.
- Bump the chart version to `1.3.17`.

Test Plan:
- `helm lint /data/users/bsuh/proxy/charts/whatsapp-proxy-chart -f /data/users/bsuh/configerator/raw_configs/cloud/helm/values/wa_unblock/whatsapp-proxy-chart/common_values.yaml -f /data/users/bsuh/configerator/raw_configs/cloud/helm/values/wa_unblock/whatsapp-proxy-chart/chat_values.yaml`
- `helm template wapox-chat /data/users/bsuh/proxy/charts/whatsapp-proxy-chart -f /data/users/bsuh/configerator/raw_configs/cloud/helm/values/wa_unblock/whatsapp-proxy-chart/common_values.yaml -f /data/users/bsuh/configerator/raw_configs/cloud/helm/values/wa_unblock/whatsapp-proxy-chart/chat_values.yaml`

Reviewers:

Subscribers:

Tasks:

Tags:
